### PR TITLE
Move `rollup` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,5 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
     "rollup": "^1.31.1"
-  },
-  "dependencies": {
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "eslint-plugin-prettier": "^3.1.2",
     "jest": "^25.1.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^1.19.1"
+    "prettier": "^1.19.1",
+    "rollup": "^1.31.1"
   },
   "dependencies": {
-    "rollup": "^1.31.1"
   }
 }


### PR DESCRIPTION
Seems like this little utility package accidentally lists `rollup` as a dependency instead of a devDependency, which ups the `node_modules` overhead from 300 bytes to over 5MB.